### PR TITLE
Step 2 add percentage occupation in dashboard

### DIFF
--- a/pms/models.py
+++ b/pms/models.py
@@ -33,9 +33,11 @@ class Room(models.Model):
 class Booking(models.Model):
     NEW = 'NEW'
     DELETED = 'DEL'
+    CONFIRMED = 'CON'
     STATE_CHOICES = [
         (NEW, 'Nueva'),
         (DELETED, 'Cancelada'),
+        (CONFIRMED, 'Confirmada'),
     ]
     state = models.CharField(
         max_length=3,

--- a/pms/templates/dashboard.html
+++ b/pms/templates/dashboard.html
@@ -4,24 +4,48 @@
 <h1>Dashboard</h1>
 <div class="card">
     <h5 class="card-header">Hoy</h5>
-    <div class="d-flex justify-content-evenly pt-5 pb-5">
-        <div class="card text-white p-3 card-customization" style="background-color: #1000ff;">
-            <h5 class="small">Reservas hechas</h5>
-            <h1 class="dashboard-value">{{dashboard.new_bookings}}</h1>
+    <div class="row">
+        <div class="col-sm-4">
+            <div class="card">
+                <div class="card-body bg-primary text-white">
+                    <h5 class="small">Reservas hechas</h5>
+                    <h1 class="dashboard-value">{{dashboard.new_bookings}}</h1>
+                </div>
+            </div>
         </div>
-        <div class="card text-white p-3 card-customization" style="background-color: #00ab74;">
-            <h5 class="small">Huéspedes ingresando</h5>
-            <h1 class="dashboard-value">{{dashboard.incoming_guests}}</h1>
+        <div class="col-sm-4">
+            <div class="card">
+                <div class="card-body bg-success text-white">
+                    <h5 class="small">Huéspedes ingresando</h5>
+                    <h1 class="dashboard-value">{{dashboard.incoming_guests}}</h1>
+                </div>
+            </div>
         </div>
-        <div class="card text-white p-3 card-customization" style="background-color: #eeb258;">
-            <h5 class="small">Huéspedes saliendo</h5>
-            <h1 class="dashboard-value">{{dashboard.outcoming_guests}}</h1>
+        <div class="col-sm-4">
+            <div class="card">
+                <div class="card-body bg-warning text-white">
+                    <h5 class="small">Huéspedes saliendo</h5>
+                    <h1 class="dashboard-value">{{dashboard.outcoming_guests}}</h1>
+                </div>
+            </div>
         </div>
-
-        <div class="card text-white p-3 card-customization" style="background-color: #ff7f7f;">
-            <h5 class="small">Total facturado</h5>
-            <h1 class="dashboard-value">€ {% if dashboard.invoiced.total__sum == None %}0.00{% endif %} {{dashboard.invoiced.total__sum|floatformat:2}}</h1>
+        <div class="col-sm-4">
+            <div class="card">
+                <div class="card-body bg-info text-white">
+                    <h5 class="small">Porcentaje de ocupacion</h5>
+                    <h1 class="dashboard-value">%{{dashboard.percentage_occupation}}</h1>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-4">
+            <div class="card">
+                <div class="card-body bg-danger text-white">
+                    <h5 class="small">Total facturado</h5>
+                    <h1 class="dashboard-value">€ {% if dashboard.invoiced.total__sum == None %}0.00{% endif %} {{dashboard.invoiced.total__sum|floatformat:2}}</h1>
+                </div>
+            </div>
         </div>
     </div>
+    
 </div>
 {% endblock content%}

--- a/pms/views.py
+++ b/pms/views.py
@@ -209,12 +209,21 @@ class DashboardView(View):
                     .aggregate(Sum('total'))
                     )
 
+        confirmed_reservations = Booking.objects.filter(
+            created__range=today_range, state=Booking.CONFIRMED
+        ).count()
+        total_active_rooms = Room.objects.all().count()
+        percentage_occupation = round(
+            (confirmed_reservations / total_active_rooms) * 100, 2
+        )
+
         # preparing context data
         dashboard = {
             'new_bookings': new_bookings,
             'incoming_guests': incoming,
             'outcoming_guests': outcoming,
-            'invoiced': invoiced
+            'invoiced': invoiced,
+            'percentage_occupation': percentage_occupation
 
         }
 


### PR DESCRIPTION
### Añadir porcentaje de ocupación
En la sección de Dashboard, se muestran varios “widgets” con datos de las reservas actuales.
Se requiere añadir un nuevo widget llamado “% ocupación”, cuyo cálculo es el siguiente:
Cantidad total de reservas en estado confirmada / número de habitaciones existentes.
Nota: Adaptar el diseño del Dashboard para mostrar este nuevo valor en la interfaz, alineado al
resto de elementos o de la forma que considere mejor el candidato.